### PR TITLE
Fix semver syntax in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "semantic-release": "semantic-release"
   },
   "peerDependencies": {
-    "next": "10.x | 11.x",
-    "react": "16.x | 17.x",
-    "react-dom": "16.x | 17.x"
+    "next": "10.x || 11.x",
+    "react": "16.x || 17.x",
+    "react-dom": "16.x || 17.x"
   },
   "dependencies": {
     "cookie": "^0.4.1",


### PR DESCRIPTION
The peer dependencies are currently using an invalid syntax.