### PR TITLE
[feat] Support cookie subdomains

### DIFF
--- a/src/api/__tests__/loginHandler.test.ts
+++ b/src/api/__tests__/loginHandler.test.ts
@@ -73,6 +73,25 @@ describe('[api] loginHandler', () => {
     jest.restoreAllMocks();
   });
 
+  it('should set the domain if configured', async () => {
+    const { req, res } = createMocks(
+      { method: 'POST', body: { password: 'password' } },
+      { eventEmitter: EventEmitter },
+    );
+
+    const domain = 'storyofams.com';
+    await loginHandler('password', { domain })(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getHeaders()).toMatchObject({
+      'set-cookie': expect.stringMatching(
+        new RegExp(
+          `^next-password-protect=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\\..+\\..+; Domain=${domain}; Path=\\/; HttpOnly$`,
+        ),
+      ),
+    });
+  });
+
   it('should reject on incorrect password', async () => {
     const { req, res } = createMocks(
       { method: 'POST', body: { password: 'incorrect' } },

--- a/src/api/loginHandler.ts
+++ b/src/api/loginHandler.ts
@@ -11,6 +11,7 @@ interface PasswordProtectHandlerOptions {
   cookieName?: string;
   cookieSameSite?: boolean | 'lax' | 'none' | 'strict';
   cookieSecure?: boolean;
+  domain?: string;
 }
 
 export const loginHandler = (
@@ -40,6 +41,7 @@ export const loginHandler = (
          */
         jwt.sign({}, password),
         {
+          domain: options?.domain,
           httpOnly: true,
           sameSite: options?.cookieSameSite || false,
           secure:


### PR DESCRIPTION
Related issue https://github.com/storyofams/next-password-protect/issues/41
## Summary
- Enables explicitly setting the cookie's domain.
- Adds corresponding test cover.